### PR TITLE
fix: set up redirect

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DashboardPage() {
+  redirect("/");
+}

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -71,6 +71,7 @@ export const routing = defineRouting({
   pathnames: {
     "#": "/#",
     "/": "/",
+    "/dashboard": "/",
     "/testnet-bridge": "/testnet-bridge",
     "/apps": "/apps",
     "/apps/[category]": "/apps/[category]",


### PR DESCRIPTION
- Set up a redirect from `/dashboard` to `/` since the Kraken Wallet still relies on `/dashboard`