### PR TITLE
feat: make links common between sidenav and mobilenav

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "3.9.1",
-    "@inkonchain/ink-kit": "0.9.1-beta.9",
+    "@inkonchain/ink-kit": "0.9.1-beta.11",
     "@next/third-parties": "15.1.6",
     "@octokit/auth-app": "7.1.3",
     "@octokit/rest": "21.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 3.9.1
         version: 3.9.1(react-hook-form@7.54.1(react@19.0.0))
       '@inkonchain/ink-kit':
-        specifier: 0.9.1-beta.9
-        version: 0.9.1-beta.9(@tanstack/react-query@5.60.6(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwindcss@4.0.8)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.14.9(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
+        specifier: 0.9.1-beta.11
+        version: 0.9.1-beta.11(@tanstack/react-query@5.60.6(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwindcss@4.0.8)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.14.9(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
       '@next/third-parties':
         specifier: 15.1.6
         version: 15.1.6(next@15.1.6(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.6))(react@19.0.0)
@@ -865,13 +865,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inkonchain/ink-kit@0.9.1-beta.9':
-    resolution: {integrity: sha512-Ni7NLiT1/Z4o0MKJgu4XtAo6L6kx60gur3phWJYuLOE9svrCGtiHnHBr54tIWwhBAXKgJSN9oROEKjMUXpnXaw==}
+  '@inkonchain/ink-kit@0.9.1-beta.11':
+    resolution: {integrity: sha512-4ltxrrWE7P0nLZsLE6Js6VJmOB1IPAsOs9T13h1tHwLEBbDPkckcvDKs5GsDz1hET+6n7iFLLMCvMaQrBmTKhQ==}
     peerDependencies:
       '@tanstack/react-query': ^5
       react: 19.0.0
       react-dom: 19.0.0
-      tailwindcss: ^3
+      tailwindcss: ^3 || ^4
       viem: ^2
       wagmi: ^2
 
@@ -7247,7 +7247,7 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inkonchain/ink-kit@0.9.1-beta.9(@tanstack/react-query@5.60.6(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwindcss@4.0.8)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.14.9(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
+  '@inkonchain/ink-kit@0.9.1-beta.11(@tanstack/react-query@5.60.6(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwindcss@4.0.8)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.14.9(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.11(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
     dependencies:
       '@headlessui/react': 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-query': 5.60.6(react@19.0.0)

--- a/src/app/[locale]/_components/MobileNav.tsx
+++ b/src/app/[locale]/_components/MobileNav.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import {
-  InkIcon,
-  InkLayoutMobileNav,
-  useInkLayoutContext,
-} from "@inkonchain/ink-kit";
+import { InkLayoutMobileNav, useInkLayoutContext } from "@inkonchain/ink-kit";
 
-import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { useRouterQuery } from "@/hooks/useRouterQuery";
 import { Link } from "@/routing";
 
+import { useLinks } from "./links";
 import { ThemeToggle } from "./ThemeToggle";
 
 export function MobileNav() {
@@ -19,8 +15,9 @@ export function MobileNav() {
     setIsMobileNavOpen(false);
   }
 
-  const hasVerifyPage = useFeatureFlag("verifyPage");
   const query = useRouterQuery();
+  const links = useLinks();
+
   return (
     <InkLayoutMobileNav
       bottom={
@@ -28,110 +25,20 @@ export function MobileNav() {
           <ThemeToggle />
         </div>
       }
-      links={[
-        {
-          href: "/",
-          asChild: true,
-          icon: <InkIcon.Home />,
-          children: (
-            <Link
-              href={{ pathname: "/", query }}
-              onClick={closeMobileNavigation}
-              prefetch
-            >
-              Home
-            </Link>
-          ),
-        },
-        {
-          href: "/apps",
-          asChild: true,
-          icon: <InkIcon.Apps />,
-          children: (
-            <Link
-              href={{ pathname: "/apps", query }}
-              onClick={closeMobileNavigation}
-              prefetch
-            >
-              Apps
-            </Link>
-          ),
-        },
-        {
-          href: "/bridge",
-          asChild: true,
-          icon: <InkIcon.Bridge />,
-          children: (
-            <Link
-              href={{ pathname: "/bridge", query }}
-              onClick={closeMobileNavigation}
-              prefetch
-            >
-              Bridge
-            </Link>
-          ),
-        },
-        ...(hasVerifyPage
-          ? [
-              {
-                href: "/verify",
-                asChild: true,
-                icon: <InkIcon.CheckFill />,
-                children: (
-                  <Link
-                    href={{ pathname: "/verify", query }}
-                    onClick={closeMobileNavigation}
-                    prefetch
-                  >
-                    Verify
-                  </Link>
-                ),
-              },
-            ]
-          : []),
-        {
-          href: "/build",
-          asChild: true,
-          icon: <InkIcon.Code />,
-          children: (
-            <Link
-              href={{ pathname: "/builders", query }}
-              onClick={closeMobileNavigation}
-              prefetch
-            >
-              Build
-            </Link>
-          ),
-        },
-        {
-          href: "/community",
-          asChild: true,
-          icon: <InkIcon.Users />,
-          children: (
-            <Link
-              href={{ pathname: "/community", query }}
-              onClick={closeMobileNavigation}
-              prefetch
-            >
-              Community
-            </Link>
-          ),
-        },
-        {
-          href: "/about",
-          asChild: true,
-          icon: <InkIcon.Info />,
-          children: (
-            <Link
-              href={{ pathname: "/about", query }}
-              onClick={closeMobileNavigation}
-              prefetch
-            >
-              About
-            </Link>
-          ),
-        },
-      ]}
+      links={links.map(({ href, icon, label }) => ({
+        href,
+        asChild: true,
+        icon,
+        children: (
+          <Link
+            href={{ pathname: href, query }}
+            onClick={closeMobileNavigation}
+            prefetch
+          >
+            {label}
+          </Link>
+        ),
+      }))}
     />
   );
 }

--- a/src/app/[locale]/_components/SideNav.tsx
+++ b/src/app/[locale]/_components/SideNav.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { InkIcon, InkLayoutSideNav, InkNavLink } from "@inkonchain/ink-kit";
+import { InkLayoutSideNav, InkNavLink } from "@inkonchain/ink-kit";
 
-import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { useRouterQuery } from "@/hooks/useRouterQuery";
 import {
   hrefObjectFromHrefPropWithQuery,
@@ -13,10 +12,11 @@ import {
   usePathname,
 } from "@/routing";
 
+import { useLinks } from "./links";
 import { ThemeToggle } from "./ThemeToggle";
 
 export const SideNav = () => {
-  const hasVerifyPage = useFeatureFlag("verifyPage");
+  const links = useLinks();
 
   return (
     <InkLayoutSideNav
@@ -25,59 +25,16 @@ export const SideNav = () => {
           <ThemeToggle />
         </div>
       }
-      links={[
-        {
-          asChild: true,
-          children: (
-            <SideNavLink href="/" exactHref>
-              Home
-            </SideNavLink>
-          ),
-          href: "/",
-          icon: <InkIcon.Home size="icon-lg" enforce="inherit" />,
-        },
-        {
-          asChild: true,
-          children: <SideNavLink href="/apps">Apps</SideNavLink>,
-          href: "/apps",
-          icon: <InkIcon.Apps size="icon-lg" enforce="inherit" />,
-        },
-        {
-          asChild: true,
-          children: <SideNavLink href="/bridge">Bridge</SideNavLink>,
-          href: "/bridge",
-          icon: <InkIcon.Bridge size="icon-lg" enforce="inherit" />,
-        },
-
-        ...(hasVerifyPage
-          ? [
-              {
-                asChild: true,
-                children: <SideNavLink href="/verify">Verify</SideNavLink>,
-                href: "/verify",
-                icon: <InkIcon.CheckFill size="icon-lg" enforce="inherit" />,
-              },
-            ]
-          : []),
-        {
-          asChild: true,
-          children: <SideNavLink href="/builders">Build</SideNavLink>,
-          href: "/builders",
-          icon: <InkIcon.Code size="icon-lg" enforce="inherit" />,
-        },
-        {
-          asChild: true,
-          children: <SideNavLink href="/community">Community</SideNavLink>,
-          href: "/community",
-          icon: <InkIcon.Users size="icon-lg" enforce="inherit" />,
-        },
-        {
-          asChild: true,
-          children: <SideNavLink href="/about">About</SideNavLink>,
-          href: "/about",
-          icon: <InkIcon.Info size="icon-lg" enforce="inherit" />,
-        },
-      ]}
+      links={links.map(({ href, icon, label, exactHref }) => ({
+        href,
+        asChild: true,
+        icon,
+        children: (
+          <SideNavLink href={href} exactHref={exactHref}>
+            {label}
+          </SideNavLink>
+        ),
+      }))}
     />
   );
 };

--- a/src/app/[locale]/_components/links.tsx
+++ b/src/app/[locale]/_components/links.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+import { InkIcon } from "@inkonchain/ink-kit";
+
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+import { Link, Pathnames, usePathname } from "@/routing";
+import { FeatureFlagKey } from "@/util/feature-flags";
+
+interface Link {
+  href: Pathnames;
+  icon: React.ReactNode;
+  label: string;
+  exactHref?: boolean;
+  flagKey?: FeatureFlagKey;
+  onlyIfOnPath?: boolean;
+}
+
+const links = [
+  {
+    href: "/",
+    icon: <InkIcon.Home />,
+    label: "Home",
+    exactHref: true,
+  },
+  {
+    href: "/apps",
+    icon: <InkIcon.Apps />,
+    label: "Apps",
+  },
+  {
+    href: "/bridge",
+    icon: <InkIcon.Bridge />,
+    label: "Bridge",
+  },
+  {
+    href: "/verify",
+    icon: <InkIcon.CheckFill />,
+    label: "Verify",
+    flagKey: "verifyPage",
+  },
+  {
+    href: "/builders",
+    icon: <InkIcon.Code />,
+    label: "Build",
+  },
+  {
+    href: "/community",
+    icon: <InkIcon.Users />,
+    label: "Community",
+  },
+  {
+    href: "/about",
+    icon: <InkIcon.Info />,
+    label: "About",
+  },
+  {
+    href: "/faucet",
+    icon: <InkIcon.Deposit />,
+    label: "Faucet",
+    onlyIfOnPath: true,
+  },
+] satisfies Link[];
+
+export function useLinks() {
+  const pathname = usePathname();
+  const verifyPage = useFeatureFlag("verifyPage");
+  const flags = useMemo(
+    () => ({
+      verifyPage,
+    }),
+    [verifyPage]
+  );
+
+  const filteredLinks = useMemo(
+    () =>
+      links.filter((link) => {
+        if (link.flagKey) {
+          return flags[link.flagKey];
+        }
+        if (link.onlyIfOnPath) {
+          return pathname.includes(link.href);
+        }
+        return true;
+      }),
+    [flags, pathname]
+  );
+
+  return filteredLinks;
+}

--- a/src/app/[locale]/verify/_components/Verifications.tsx
+++ b/src/app/[locale]/verify/_components/Verifications.tsx
@@ -166,7 +166,7 @@ const MobileVerificationsTable = () => {
   return (
     <div className="w-full border-collapse ink:bg-background-container rounded-2xl lg:hidden">
       <div className="text-right border-b border-blackMagic/10 dark:border-whiteMagic/10 ink:text-text-muted ink:text-body-3-bold">
-        <th className="py-4 px-6 text-left">Verification</th>
+        <div className="py-4 px-6 text-left">Verification</div>
       </div>
       <div className="flex flex-col gap-4">
         {VERIFICATIONS.map((verification) => (

--- a/src/contexts/CaptchaProvider.tsx
+++ b/src/contexts/CaptchaProvider.tsx
@@ -3,7 +3,6 @@
 import React, {
   createContext,
   PropsWithChildren,
-  ReactNode,
   useCallback,
   useContext,
   useState,


### PR DESCRIPTION
Ensures that the links are the same, in the same order, for Mobile and SideNav.

Also adds the possibility of adding links that only appear when you are on their page, such as the faucet page:

![image](https://github.com/user-attachments/assets/286073d4-1fb3-44b9-8414-b3bca3f8e4c4)

I think it looks cleaner if there is an entry in the side nav :P 