### PR TITLE
fix: various typo fixes

### DIFF
--- a/src/actions/resubscribe-to-braze.ts
+++ b/src/actions/resubscribe-to-braze.ts
@@ -17,8 +17,8 @@ export async function resubscribeToBraze(
   formData: FormData
 ): Promise<FormState> {
   const brazeId = formData.get("brazeId");
-  const generalWailist = formData.get("generalWailist");
-  const developerWailist = formData.get("developerWailist");
+  const generalWaitlist = formData.get("generalWaitlist");
+  const developerWaitlist = formData.get("developerWaitlist");
 
   if (!brazeId || typeof brazeId !== "string") {
     return {
@@ -27,14 +27,14 @@ export async function resubscribeToBraze(
     };
   }
 
-  if (generalWailist !== "on" && developerWailist !== "on") {
+  if (generalWaitlist !== "on" && developerWaitlist !== "on") {
     return {
       error: "Make sure to select at least one of the waitlists",
       success: false,
     };
   }
 
-  if (generalWailist === "on") {
+  if (generalWaitlist === "on") {
     try {
       await changeUserSubscriptionGroupStatus(
         brazeId,
@@ -50,7 +50,7 @@ export async function resubscribeToBraze(
     }
   }
 
-  if (developerWailist === "on") {
+  if (developerWaitlist === "on") {
     try {
       await changeUserSubscriptionGroupStatus(
         brazeId,

--- a/src/actions/unsubscribe-from-braze.ts
+++ b/src/actions/unsubscribe-from-braze.ts
@@ -18,8 +18,8 @@ export async function unsubscribeFromBraze(
   formData: FormData
 ): Promise<FormState> {
   const brazeId = formData.get("brazeId");
-  const generalWailist = formData.get("generalWailist");
-  const developerWailist = formData.get("developerWailist");
+  const generalWaitlist = formData.get("generalWaitlist");
+  const developerWaitlist = formData.get("developerWaitlist");
 
   if (!brazeId || typeof brazeId !== "string") {
     return {
@@ -28,14 +28,14 @@ export async function unsubscribeFromBraze(
     };
   }
 
-  if (generalWailist !== "on" && developerWailist !== "on") {
+  if (generalWaitlist !== "on" && developerWaitlist !== "on") {
     return {
       error: "Make sure to select at least one of the waitlists",
       success: false,
     };
   }
 
-  if (generalWailist === "on") {
+  if (generalWaitlist === "on") {
     try {
       await changeUserSubscriptionGroupStatus(
         brazeId,
@@ -51,7 +51,7 @@ export async function unsubscribeFromBraze(
     }
   }
 
-  if (developerWailist === "on") {
+  if (developerWaitlist === "on") {
     try {
       await changeUserSubscriptionGroupStatus(
         brazeId,

--- a/src/app/[locale]/(info)/terms/terms-before-mainnet.tsx
+++ b/src/app/[locale]/(info)/terms/terms-before-mainnet.tsx
@@ -644,7 +644,7 @@ export default function TermsBeforeMainnet() {
       <div className="underline">Survival.</div>
       <div>
         If these Terms expire or terminate, the following Sections will remain
-        fully binding upon you and us: 1, 2, 2, 3, 4, 5, 6, 8, 9, 10, and 11.
+        fully binding upon you and us: 1, 2, 3, 4, 5, 6, 8, 9, 10, and 11.
         Termination won&apos;t limit any of our rights or remedies at law or
         equity.
       </div>

--- a/src/app/[locale]/(info)/terms/terms-before-mainnet.tsx
+++ b/src/app/[locale]/(info)/terms/terms-before-mainnet.tsx
@@ -215,7 +215,7 @@ export default function TermsBeforeMainnet() {
         software, including any upgrades, that the Ink is built on may introduce
         bugs, viruses, Trojan horses, or other vulnerabilities or changes to Ink
         that could result in a partial or complete disruption of Ink or loss,
-        damage, or destruction of your Digital Assets. IWe do not control third
+        damage, or destruction of your Digital Assets. We do not control third
         party applications, including their development or deployment, on Ink,
         or any activity or transactions occurring on Ink. Therefore, you
         acknowledge and agree that Ink, including its Bridge Smart Contracts,

--- a/src/app/[locale]/(info)/wizarding-academy-rules/page.tsx
+++ b/src/app/[locale]/(info)/wizarding-academy-rules/page.tsx
@@ -92,13 +92,13 @@ export default function TrainingGroundRules() {
       </p>
 
       <ColoredText variant="purple" className="text-4xl">
-        3. Daap Cosponsors
+        3. Dapp Cosponsors
       </ColoredText>
 
       <p>
         In the event that an Academy Session is co-sponsored by a Dapp, such
         co-sponsorship does not constitute an endorsement of the Dapp, its
-        personnel, or its products or services by Ink. Further, the Daap
+        personnel, or its products or services by Ink. Further, the Dapp
         cosponsor will be solely responsible and liable for the determination
         and notification of winners and providing any prizes. As a result, you
         acknowledge and agree that Ink makes no representations or warranties,
@@ -116,7 +116,7 @@ export default function TrainingGroundRules() {
       <p>
         If a task requires submission of content for judgment, each participant
         is limited to submitting one eligible entry. Multiple submissions will
-        not be considered. Each submission will be judged by Ink or the Daap
+        not be considered. Each submission will be judged by Ink or the Dapp
         co-sponsor, in its sole discretion, in accordance with the judging
         criteria announced for that task. In the event no criteria is mentioned,
         judging will be based on originality and creativity (equally weighted)


### PR DESCRIPTION
This PR fixes multiple spelling errors and minor inconsistencies across various files in the codebase.  

## Changes  
- Corrected "Wailist" to **"Waitlist"** in `resubscribe-to-braze.ts` and `unsubscribe-from-braze.ts`.  
- Corrected "IWe" to **"We"** in `terms-before-mainnet.tsx`.  
- Fixed duplicate section reference "1, 2, 2, 3, 4..." to **"1, 2, 3, 4..."** in `terms-before-mainnet.tsx`.  
- Corrected "Daap" to **"Dapp"** in `wizarding-academy-rules/page.tsx`.  

