### PR TITLE
feat: add health check endpoint with dependency monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 
 # Cache
 cache/*
+.temp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help release
+.PHONY: help release dev build start lint lint-fix format format-check test fix-all install clean health-test
 
 help: ## Show this help message
 	@echo "\033[1mAvailable commands:\033[0m"
@@ -36,4 +36,51 @@ release: ## Interactive release command with enhanced developer experience
 	else \
 		echo ""; \
 		echo "\033[1;31m❌ Cancelled creating release tag\033[0m"; \
-	fi 
+	fi
+
+# Development commands
+dev: ## Start development server with turbo
+	pnpm run dev
+
+dev-https: ## Start development server with HTTPS
+	pnpm run dev:https
+
+build: ## Build the application for production
+	pnpm run build
+
+start: ## Start production server
+	pnpm run start
+
+# Code quality commands
+lint: ## Run ESLint
+	pnpm run lint
+
+lint-fix: ## Run ESLint with auto-fix
+	pnpm run lint:fix
+
+format: ## Format code with Prettier
+	pnpm run format
+
+format-check: ## Check code formatting
+	pnpm run format:check
+
+test: ## Run Playwright tests
+	pnpm run test
+
+fix-all: ## Run lint:fix and format
+	pnpm run fix:all
+
+# Package management
+install: ## Install dependencies
+	pnpm install
+
+clean: ## Clean node_modules and lockfile
+	rm -rf node_modules pnpm-lock.yaml
+
+# Health check testing
+health-test: ## Test health endpoint (requires dev server running)
+	@echo "\033[1mTesting basic health check...\033[0m"
+	@curl -s http://localhost:3000/api/health | jq . || curl -s http://localhost:3000/api/health
+	@echo ""
+	@echo "\033[1mTesting deep health check...\033[0m"
+	@curl -s http://localhost:3000/api/health?deep=true | jq . || curl -s http://localhost:3000/api/health?deep=true

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { env } from "@/env";
+import { clientEnv } from "@/env-client";
+
+// Health check timeout in milliseconds
+const HEALTH_CHECK_TIMEOUT_MS = 5000;
+
+interface ServiceStatus {
+  status: "healthy" | "unhealthy";
+  responseTime?: number;
+  error?: string;
+}
+
+interface HealthResponse {
+  status: "healthy" | "degraded" | "unhealthy";
+  timestamp: string;
+  services: {
+    app: ServiceStatus;
+    krakenVerifyApi?: ServiceStatus;
+    faucetApi?: ServiceStatus;
+  };
+}
+
+async function checkServiceHealth(
+  url: string,
+  timeout: number = HEALTH_CHECK_TIMEOUT_MS
+): Promise<ServiceStatus> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const startTime = Date.now();
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "Ink-WebApp-HealthCheck/1.0",
+      },
+    });
+    const responseTime = Date.now() - startTime;
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return {
+        status: "healthy",
+        responseTime,
+      };
+    } else {
+      return {
+        status: "unhealthy",
+        responseTime,
+        error: `HTTP ${response.status}`,
+      };
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    console.error(`Health check failed for ${url}:`, errorMessage);
+    return {
+      status: "unhealthy",
+      error: errorMessage,
+    };
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const deep = searchParams.get("deep") === "true";
+
+  const healthResponse: HealthResponse = {
+    status: "healthy",
+    timestamp: new Date().toISOString(),
+    services: {
+      app: { status: "healthy", responseTime: 0 },
+    },
+  };
+
+  if (deep) {
+    const healthChecks = await Promise.allSettled([
+      checkServiceHealth(`${env.KRAKEN_VERIFY_API_BASE_URL}/health`),
+      checkServiceHealth(clientEnv.NEXT_PUBLIC_FAUCET_API_URL || ""),
+    ]);
+
+    const [krakenResult, faucetResult] = healthChecks;
+
+    if (krakenResult.status === "fulfilled") {
+      healthResponse.services.krakenVerifyApi = krakenResult.value;
+    } else {
+      console.error(
+        "Kraken Verify API health check failed:",
+        krakenResult.reason
+      );
+      healthResponse.services.krakenVerifyApi = {
+        status: "unhealthy",
+        error: "Health check failed",
+      };
+    }
+
+    if (faucetResult.status === "fulfilled") {
+      healthResponse.services.faucetApi = faucetResult.value;
+    } else {
+      console.error("Faucet API health check failed:", faucetResult.reason);
+      healthResponse.services.faucetApi = {
+        status: "unhealthy",
+        error: "Health check failed",
+      };
+    }
+
+    const criticalServicesUnhealthy =
+      healthResponse.services.krakenVerifyApi?.status === "unhealthy";
+    const nonCriticalServicesUnhealthy =
+      healthResponse.services.faucetApi?.status === "unhealthy";
+
+    if (criticalServicesUnhealthy) {
+      healthResponse.status = "unhealthy";
+    } else if (nonCriticalServicesUnhealthy) {
+      healthResponse.status = "degraded";
+    }
+  }
+
+  const httpStatus = healthResponse.status === "unhealthy" ? 503 : 200;
+
+  return NextResponse.json(healthResponse, {
+    status: httpStatus,
+    headers: {
+      "Cache-Control": "no-cache",
+    },
+  });
+}


### PR DESCRIPTION
- Add `/api/health` endpoint with basic liveness check
- Add `/api/health?deep=true` for external service health checks  
- Monitor `Kraken Verify API` and `Faucet API` connectivity
- Return structured JSON with service status and response times
- Add 5-second timeout with graceful error handling
- Include `Cache-Control: no-cache` header
- Add enhanced `Makefile` with common development commands
- Add `health-test` make target for endpoint testing