### PR TITLE
Fix typo in MorpheusMeshMaterial warning comment

### DIFF
--- a/src/components/MainBackground/Morpheus.tsx
+++ b/src/components/MainBackground/Morpheus.tsx
@@ -74,7 +74,7 @@ export class MorpheusMeshMaterial extends THREE.MeshPhysicalMaterial {
     }
   }
 
-  // Carefull this happens everyframe
+  // Careful, this happens everyframe
   incrementTime(deltaTime: number) {
     if (this.userData.shader) {
       this.userData.shader.uniforms.uTime.value += deltaTime;


### PR DESCRIPTION


**Description:**  
Corrected a typo in the warning comment from "Carefull" to "Careful" for better clarity and professionalism.  
