### PR TITLE
feat: implement secure newsletter unsubscribe system with jwt tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,11 @@ INK_APP_SUBMISSION_SLACK_BOT_TOKEN=
 # Testnet Faucet Experiment
 NEXT_PUBLIC_FAUCET_API_URL=
 MULTIPLIER_JWT_SECRET=
+
+# Newsletter Unsubscribe Security
+# Generate with: openssl rand -base64 32
+UNSUBSCRIBE_JWT_SECRET=
+
+# Braze Connected Content
+# Dedicated API key for Connected Content requests with limited permissions
+BRAZE_CONNECTED_CONTENT_API_KEY=

--- a/src/actions/subscribe-to-braze.ts
+++ b/src/actions/subscribe-to-braze.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { clientEnv } from "@/env-client";
 import {
   subscribeUserToGroup,
   SubscriptionGroup,
@@ -57,23 +58,25 @@ async function subscribeToBrazeGroups(
   const email = formData.get("email");
   const captchaToken = formData.get("captchaToken");
 
-  if (!captchaToken || typeof captchaToken !== "string") {
-    return {
-      error: {
-        form: "Captcha verification required",
-      },
-      success: false,
-    };
-  }
+  if (!clientEnv.NEXT_PUBLIC_DISABLE_CAPTCHA) {
+    if (!captchaToken || typeof captchaToken !== "string") {
+      return {
+        error: {
+          form: "Captcha verification required",
+        },
+        success: false,
+      };
+    }
 
-  const isCaptchaValid = await validateCaptcha(captchaToken);
-  if (!isCaptchaValid) {
-    return {
-      error: {
-        form: "Captcha verification failed",
-      },
-      success: false,
-    };
+    const isCaptchaValid = await validateCaptcha(captchaToken);
+    if (!isCaptchaValid) {
+      return {
+        error: {
+          form: "Captcha verification failed",
+        },
+        success: false,
+      };
+    }
   }
 
   if (!email || typeof email !== "string" || !isValidEmail(email)) {

--- a/src/actions/unsubscribe-from-braze.ts
+++ b/src/actions/unsubscribe-from-braze.ts
@@ -14,10 +14,11 @@ interface FormState {
 }
 
 export async function unsubscribeFromBraze(
-  prevState: FormState,
+  _prevState: FormState,
   formData: FormData
 ): Promise<FormState> {
   const brazeId = formData.get("brazeId");
+  const email = formData.get("email");
   const generalWailist = formData.get("generalWailist");
   const developerWailist = formData.get("developerWailist");
 
@@ -45,7 +46,6 @@ export async function unsubscribeFromBraze(
     } catch {
       return {
         success: false,
-
         error: "Issue submitting form",
       };
     }
@@ -61,13 +61,12 @@ export async function unsubscribeFromBraze(
     } catch {
       return {
         success: false,
-
         error: "Issue submitting form",
       };
     }
   }
 
-  const { users } = await listUserSubscriptionGroups(brazeId);
+  const { users } = await listUserSubscriptionGroups(brazeId, email as string);
 
   if (!users || users.length === 0) {
     return {
@@ -87,7 +86,6 @@ export async function unsubscribeFromBraze(
     } catch {
       return {
         success: false,
-
         error: "Issue submitting form",
       };
     }
@@ -95,7 +93,6 @@ export async function unsubscribeFromBraze(
 
   return {
     success: true,
-
     error: undefined,
   };
 }

--- a/src/app/[locale]/newsletter/resubscribe/_components/ResubscribeForm.tsx
+++ b/src/app/[locale]/newsletter/resubscribe/_components/ResubscribeForm.tsx
@@ -57,6 +57,14 @@ export const ResubscribeForm: React.FC<ResubscribeFormProps> = ({
           aria-hidden
           readOnly
         />
+        <input
+          id="email"
+          name="email"
+          value={email}
+          className="hidden"
+          aria-hidden
+          readOnly
+        />
 
         <div className="h-6 flex items-center">
           <input

--- a/src/app/[locale]/newsletter/unsubscribe/_components/UnsubscribeForm.tsx
+++ b/src/app/[locale]/newsletter/unsubscribe/_components/UnsubscribeForm.tsx
@@ -11,11 +11,13 @@ import { Link } from "@/routing";
 interface UnsubscribeFormProps {
   userBrazeId: string;
   email: string;
+  token: string;
 }
 
 export const UnsubscribeForm: React.FC<UnsubscribeFormProps> = ({
   userBrazeId,
   email,
+  token,
 }) => {
   const [state, formAction] = useActionState(unsubscribeFromBraze, {
     success: false,
@@ -34,10 +36,10 @@ export const UnsubscribeForm: React.FC<UnsubscribeFormProps> = ({
           <Link
             href={{
               pathname: "/newsletter/resubscribe",
-              query: { id: userBrazeId },
+              query: { token },
             }}
           >
-            Resuscribe
+            Resubscribe
           </Link>
         </Button>
       </div>
@@ -53,6 +55,14 @@ export const UnsubscribeForm: React.FC<UnsubscribeFormProps> = ({
           id="brazeId"
           name="brazeId"
           value={userBrazeId}
+          className="hidden"
+          aria-hidden
+          readOnly
+        />
+        <input
+          id="email"
+          name="email"
+          value={email}
           className="hidden"
           aria-hidden
           readOnly

--- a/src/app/api/auth/callback/kraken/route.ts
+++ b/src/app/api/auth/callback/kraken/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 
-const isProduction = process.env.NEXT_PUBLIC_ENVIRONMENT === "production";
+import { clientEnv } from "@/env-client";
+
+const isProduction = clientEnv.NEXT_PUBLIC_ENVIRONMENT === "production";
 
 const ALLOWED_DOMAINS = [
   "inkonchain.com",
@@ -20,8 +22,6 @@ export async function GET(request: Request) {
     }
 
     const host = request.headers.get("host");
-
-    console.log(`AUTH CALLBACK [host]: ${host}`);
 
     const isAllowedHost = ALLOWED_DOMAINS.some(
       (domain) => host === domain || host?.endsWith(`.${domain}`)

--- a/src/app/api/newsletter/generate-unsubscribe-token/route.ts
+++ b/src/app/api/newsletter/generate-unsubscribe-token/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { env } from "@/env";
+import { generateUnsubscribeToken } from "@/lib/unsubscribe-token";
+
+// Braze Connected Content IP ranges
+// Reference: https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content/making_an_api_call
+const BRAZE_IP_RANGES = [
+  // US Instances (US-01 to US-07)
+  "23.21.118.191",
+  "34.206.23.173",
+  "50.16.249.9",
+  "52.4.160.214",
+  "54.87.8.34",
+  "54.156.35.251",
+  "52.54.89.238",
+  "18.205.178.15",
+  // US-08
+  "52.151.246.51",
+  "52.170.163.182",
+  "40.76.166.157",
+  "40.76.166.170",
+  "40.76.166.167",
+  "40.76.166.161",
+  "40.76.166.156",
+  "40.76.166.166",
+  "40.76.166.160",
+  "40.88.51.74",
+  "52.154.67.17",
+  "40.76.166.80",
+  "40.76.166.84",
+  "40.76.166.85",
+  "40.76.166.81",
+  "40.76.166.71",
+  "40.76.166.144",
+  "40.76.166.145",
+  // US-10
+  "100.25.232.164",
+  "35.168.86.179",
+  "52.7.44.117",
+  "3.92.153.18",
+  "35.172.3.129",
+  "50.19.162.19",
+  // EU Instances
+  "52.58.142.242",
+  "52.29.193.121",
+  "35.158.29.228",
+  "18.157.135.97",
+  "3.123.166.46",
+  "3.64.27.36",
+  "3.65.88.25",
+  "3.68.144.188",
+  "3.70.107.88",
+  // AU-01
+  "13.210.1.145",
+  "13.211.70.159",
+  "13.238.45.54",
+  "52.65.73.167",
+  "54.153.242.239",
+  "54.206.45.213",
+  // ID-01
+  "108.136.157.246",
+  "108.137.30.207",
+  "16.78.128.71",
+  "16.78.14.134",
+  "16.78.162.208",
+  "43.218.73.35",
+];
+
+function isIpAllowed(ip: string): boolean {
+  return BRAZE_IP_RANGES.includes(ip);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Get client IP address
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    const realIp = request.headers.get("x-real-ip");
+    const requestIp = forwardedFor?.split(",")[0].trim() || realIp || "unknown";
+
+    // Verify IP is from Braze
+    if (!isIpAllowed(requestIp)) {
+      console.warn(`Unauthorized request from IP: ${requestIp}`);
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Verify the request is coming from Braze using the dedicated Connected Content API key
+    const apiKey = request.headers.get("X-Braze-Connected-Content-Api-Key");
+    if (!apiKey || apiKey !== env.BRAZE_CONNECTED_CONTENT_API_KEY) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Extract required headers
+    const brazeId = request.headers.get("X-Braze-Id");
+    const email = request.headers.get("X-Email");
+    const campaignId = request.headers.get("X-Campaign-Id");
+
+    if (!brazeId || !email) {
+      return NextResponse.json(
+        { error: "Missing required headers: X-Braze-Id and X-Email" },
+        { status: 400 }
+      );
+    }
+
+    // Generate JWT token
+    const token = await generateUnsubscribeToken({
+      email,
+      brazeId,
+      campaignId: campaignId || undefined,
+      sentAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ token });
+  } catch (error) {
+    console.error("Error generating unsubscribe token:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/env-client.ts
+++ b/src/env-client.ts
@@ -18,6 +18,10 @@ export const clientEnv = createEnv({
       .string()
       .url()
       .default("https://explorer.inkonchain.com"),
+    NEXT_PUBLIC_DISABLE_CAPTCHA: z
+      .string()
+      .optional()
+      .transform((val) => val === "true"),
   },
   runtimeEnv: {
     NEXT_PUBLIC_ENVIRONMENT: process.env.NEXT_PUBLIC_ENVIRONMENT,
@@ -31,5 +35,6 @@ export const clientEnv = createEnv({
     NEXT_PUBLIC_FAUCET_API_URL: process.env.NEXT_PUBLIC_FAUCET_API_URL,
     NEXT_PUBLIC_VERIFY_EXPLORER_BASE_URL:
       process.env.NEXT_PUBLIC_VERIFY_EXPLORER_BASE_URL,
+    NEXT_PUBLIC_DISABLE_CAPTCHA: process.env.NEXT_PUBLIC_DISABLE_CAPTCHA,
   },
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,6 +24,8 @@ export const env = createEnv({
     INK_APP_SUBMISSION_SLACK_NOTIFICATION_CHANNEL: z.string().min(1),
     HCAPTCHA_SECRET: z.string().min(1),
     MULTIPLIER_JWT_SECRET: z.string().min(1),
+    UNSUBSCRIBE_JWT_SECRET: z.string().min(1),
+    BRAZE_CONNECTED_CONTENT_API_KEY: z.string().min(1),
   },
   experimental__runtimeEnv: process.env,
 });

--- a/src/integrations/braze.ts
+++ b/src/integrations/braze.ts
@@ -116,7 +116,17 @@ interface ListUserSubscriptionGroupsReturn {
   }>;
 }
 
-export async function listUserSubscriptionGroups(brazeUserId: string) {
+export async function listUserSubscriptionGroups(
+  brazeUserId: string,
+  email?: string
+) {
+  // If email is provided, use it (more reliable than braze_id)
+  if (email) {
+    return getFromBraze<ListUserSubscriptionGroupsReturn>(
+      `/subscription/user/status?email=${encodeURIComponent(email)}`
+    );
+  }
+  // Fallback to external_id approach
   return getFromBraze<ListUserSubscriptionGroupsReturn>(
     `/subscription/user/status?external_id=${brazeUserId}`
   );

--- a/src/lib/hcaptcha.ts
+++ b/src/lib/hcaptcha.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env";
+import { clientEnv } from "@/env-client";
 
 interface HCaptchaVerifyResponse {
   success: boolean;
@@ -9,6 +10,10 @@ interface HCaptchaVerifyResponse {
 }
 
 export async function validateCaptcha(token: string): Promise<boolean> {
+  if (clientEnv.NEXT_PUBLIC_DISABLE_CAPTCHA) {
+    return true;
+  }
+
   try {
     const formData = new URLSearchParams();
     formData.append("secret", env.HCAPTCHA_SECRET);

--- a/src/lib/unsubscribe-token.ts
+++ b/src/lib/unsubscribe-token.ts
@@ -1,0 +1,43 @@
+import { JWTPayload, jwtVerify, SignJWT } from "jose";
+
+import { env } from "@/env";
+
+const UNSUBSCRIBE_JWT_SECRET_KEY = new TextEncoder().encode(
+  env.UNSUBSCRIBE_JWT_SECRET
+);
+
+export interface UnsubscribeTokenPayload extends JWTPayload {
+  email: string;
+  brazeId: string;
+  campaignId?: string;
+  sentAt: string;
+}
+
+export async function generateUnsubscribeToken(
+  payload: UnsubscribeTokenPayload
+): Promise<string> {
+  return await new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .sign(UNSUBSCRIBE_JWT_SECRET_KEY);
+}
+
+export async function validateUnsubscribeToken(
+  token: string
+): Promise<UnsubscribeTokenPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, UNSUBSCRIBE_JWT_SECRET_KEY);
+
+    if (
+      typeof payload.email !== "string" ||
+      typeof payload.brazeId !== "string" ||
+      typeof payload.sentAt !== "string"
+    ) {
+      return null;
+    }
+
+    return payload as UnsubscribeTokenPayload;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- Replaced URL parameter-based unsubscribe system with secure `JWT` token validation
- Added `UNSUBSCRIBE_JWT_SECRET` environment variable for token signing with `HMAC-SHA256`
- Created `/api/newsletter/generate-unsubscribe-token` endpoint with `IP allowlisting` for `Braze Connected Content`
- Implemented `validateUnsubscribeToken` function for secure token verification
- Updated unsubscribe and resubscribe pages to use server-side token validation with `notFound()`
- Enhanced `listUserSubscriptionGroups` to accept email parameter for more reliable user lookup
- Added `BRAZE_CONNECTED_CONTENT_API_KEY` for dedicated API access control
- Improved resubscribe logic to check previous subscription status before email updates
- Added `NEXT_PUBLIC_DISABLE_CAPTCHA` environment variable for development workflow
- Fixed typo: `Resuscribe` → `Resubscribe` in unsubscribe form
- Removed debug logging from `Kraken` auth callback for cleaner logs
